### PR TITLE
[FEAT] 사용자 회원가입 API 구현

### DIFF
--- a/src/main/java/com/lucky/around/meal/controller/MemberController.java
+++ b/src/main/java/com/lucky/around/meal/controller/MemberController.java
@@ -1,0 +1,31 @@
+package com.lucky.around.meal.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.lucky.around.meal.controller.record.RegisterRecord;
+import com.lucky.around.meal.service.MemberService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberController {
+
+  private final MemberService memberService;
+
+  @PostMapping
+  public ResponseEntity<String> singUp(@RequestBody RegisterRecord registerRecord) {
+    // 계정명 중복 검증
+    memberService.isExistInDB(registerRecord);
+    // 회원가입
+    memberService.signUp(registerRecord);
+    return ResponseEntity.ok("회원가입이 성공적으로 완료되었습니다.");
+  }
+}

--- a/src/main/java/com/lucky/around/meal/controller/record/RegisterRecord.java
+++ b/src/main/java/com/lucky/around/meal/controller/record/RegisterRecord.java
@@ -1,0 +1,18 @@
+package com.lucky.around.meal.controller.record;
+
+import com.lucky.around.meal.entity.Member;
+import com.lucky.around.meal.entity.enums.MemberRole;
+
+public record RegisterRecord(String memberName, String password, String email) {
+
+  public Member toMember() {
+    return Member.builder()
+        .memberName(memberName())
+        .password(password())
+        .email(email())
+        .lat(0)
+        .lon(0)
+        .role(MemberRole.USER)
+        .build();
+  }
+}

--- a/src/main/java/com/lucky/around/meal/exception/exceptionType/RegisterExceptionType.java
+++ b/src/main/java/com/lucky/around/meal/exception/exceptionType/RegisterExceptionType.java
@@ -1,0 +1,26 @@
+package com.lucky.around.meal.exception.exceptionType;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum RegisterExceptionType implements ExceptionType {
+  DUPLICATED_MEMBER_NAME(HttpStatus.CONFLICT, "이미 사용 중인 계정입니다.");
+
+  private final HttpStatus status;
+  private final String message;
+
+  @Override
+  public HttpStatus status() {
+    return this.status;
+  }
+
+  @Override
+  public String message() {
+    return this.message;
+  }
+}

--- a/src/main/java/com/lucky/around/meal/repository/MemberRepository.java
+++ b/src/main/java/com/lucky/around/meal/repository/MemberRepository.java
@@ -8,4 +8,6 @@ import com.lucky.around.meal.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
   Optional<Member> findByMemberName(String memberName);
+
+  boolean existsByMemberName(String memberName);
 }

--- a/src/main/java/com/lucky/around/meal/service/MemberService.java
+++ b/src/main/java/com/lucky/around/meal/service/MemberService.java
@@ -23,7 +23,7 @@ public class MemberService {
     // DB에서 계정명 중복 검증
     boolean isExist = memberRepository.existsByMemberName(registerRecord.memberName());
     // 중복 존재할 시 예외 리턴
-    if (!isExist) {
+    if (isExist) {
       throw new CustomException(RegisterExceptionType.DUPLICATED_MEMBER_NAME);
     }
   }

--- a/src/main/java/com/lucky/around/meal/service/MemberService.java
+++ b/src/main/java/com/lucky/around/meal/service/MemberService.java
@@ -1,0 +1,38 @@
+package com.lucky.around.meal.service;
+
+import org.springframework.stereotype.Service;
+
+import com.lucky.around.meal.controller.record.RegisterRecord;
+import com.lucky.around.meal.entity.Member;
+import com.lucky.around.meal.exception.CustomException;
+import com.lucky.around.meal.exception.exceptionType.RegisterExceptionType;
+import com.lucky.around.meal.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+  private final MemberRepository memberRepository;
+
+  // 계정명 중복 검증
+  public void isExistInDB(RegisterRecord registerRecord) {
+    // DB에서 계정명 중복 검증
+    boolean isExist = memberRepository.existsByMemberName(registerRecord.memberName());
+    // 중복 존재할 시 예외 리턴
+    if (!isExist) {
+      throw new CustomException(RegisterExceptionType.DUPLICATED_MEMBER_NAME);
+    }
+  }
+
+  // 회원가입
+  public void signUp(RegisterRecord registerRecord) {
+    // RegisterRecord 를 Member 엔티티로 변환
+    Member member = registerRecord.toMember();
+    // DB 저장
+    memberRepository.save(member);
+  }
+}


### PR DESCRIPTION
## 🍚 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #7 

## 🍚 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 사용자 회원가입 API를 구현하였습니다.

## 🍚 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 회원가입 성공

![회원가입 성공](https://github.com/user-attachments/assets/1034cea2-c822-4729-94b9-2dae20dd19b2)

- 회원가입 실패(중복된 계정명)

![회원가입 실패](https://github.com/user-attachments/assets/0d609208-0c2e-44f7-ae56-3c3c10a55b6b)

## 🍚 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
- 