### PR TITLE
[REFACTOR] 평가 생성 API 수정 및 평점 평균 계산 추가

### DIFF
--- a/src/main/java/com/lucky/around/meal/controller/response/RestaurantDetailResponseDto.java
+++ b/src/main/java/com/lucky/around/meal/controller/response/RestaurantDetailResponseDto.java
@@ -13,5 +13,5 @@ public record RestaurantDetailResponseDto(
     String restaurantTel,
     double lon,
     double lat,
-    // double ratingAverage,
+    double ratingAverage,
     List<RatingResponseDto> rating) {}

--- a/src/main/java/com/lucky/around/meal/entity/Restaurant.java
+++ b/src/main/java/com/lucky/around/meal/entity/Restaurant.java
@@ -48,7 +48,8 @@ public class Restaurant {
       String doroDetailAddress,
       Category category,
       String restaurantTel,
-      Point location) {
+      Point location,
+      double ratingAverage) {
     this.id = id;
     this.restaurantName = restaurantName;
     this.dosi = dosi;
@@ -58,6 +59,11 @@ public class Restaurant {
     this.category = category;
     this.restaurantTel = restaurantTel;
     this.location = location;
+    this.ratingAverage = ratingAverage;
+  }
+
+  public void updateRatingAverage(double ratingAverage) {
+    this.ratingAverage = ratingAverage;
   }
 
   public String getJibunAddress() {

--- a/src/main/java/com/lucky/around/meal/exception/exceptionType/MemberExceptionType.java
+++ b/src/main/java/com/lucky/around/meal/exception/exceptionType/MemberExceptionType.java
@@ -1,0 +1,26 @@
+package com.lucky.around.meal.exception.exceptionType;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum MemberExceptionType implements ExceptionType {
+  NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
+
+  private final HttpStatus status;
+  private final String message;
+
+  @Override
+  public HttpStatus status() {
+    return this.status;
+  }
+
+  @Override
+  public String message() {
+    return this.message;
+  }
+}

--- a/src/main/java/com/lucky/around/meal/service/RatingService.java
+++ b/src/main/java/com/lucky/around/meal/service/RatingService.java
@@ -9,6 +9,7 @@ import com.lucky.around.meal.entity.Member;
 import com.lucky.around.meal.entity.Rating;
 import com.lucky.around.meal.entity.Restaurant;
 import com.lucky.around.meal.exception.CustomException;
+import com.lucky.around.meal.exception.exceptionType.MemberExceptionType;
 import com.lucky.around.meal.exception.exceptionType.RestaurantExceptionType;
 import com.lucky.around.meal.repository.MemberRepository;
 import com.lucky.around.meal.repository.RatingRepository;
@@ -27,11 +28,10 @@ public class RatingService {
   @Transactional
   public RatingResponseDto createRating(RatingRequestDto requestDto) {
 
-    // todo : 회원 예외처리
     Member member =
         memberRepository
             .findById(requestDto.memberId())
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+            .orElseThrow(() -> new CustomException(MemberExceptionType.NOT_FOUND_MEMBER));
 
     Restaurant restaurant =
         restaurantRepository

--- a/src/main/java/com/lucky/around/meal/service/RatingService.java
+++ b/src/main/java/com/lucky/around/meal/service/RatingService.java
@@ -51,6 +51,10 @@ public class RatingService {
     // 식당 평균 score 계산
     Double ratingAverage = ratingRepository.findAvgScoreByRestaurantId(requestDto.restaurantId());
 
+    restaurant.updateRatingAverage(ratingAverage); // 평균 변화
+
+    restaurantRepository.save(restaurant); // 저장
+
     return new RatingResponseDto(
         rating.getId(),
         rating.getMember().getMemberId(),

--- a/src/main/java/com/lucky/around/meal/service/RestaurantService.java
+++ b/src/main/java/com/lucky/around/meal/service/RestaurantService.java
@@ -71,7 +71,7 @@ public class RestaurantService {
         restaurant.getRestaurantTel(),
         restaurant.getLocation().getX(),
         restaurant.getLocation().getY(),
-        // restaurant.getRatingAverage(),
+        restaurant.getRatingAverage(),
         ratings);
   }
 


### PR DESCRIPTION
## 🍚 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #54 

## 🍚 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 평균값 계산을 위해 레스토랑 엔티티 내 updateRatingAverage 메서드 추가
- 맛집 상세 페이지 내 평균 점수 업데이트 완료 (주석처리 해두셨던 부분 풀었습니다!)
- 평가 생성 시 존재하지 않는 회원 예외처리 추가

## 🍚 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

### GET /api/restaurants/{restaurantId}
```
{
{
    "restaurantId": "3010000-101-2023-00540",
    "restaurantName": "매취랑 동대문점",
    "dosi": "서울특별시",
    "sigungu": "중구",
    "jibunDetailAddress": "을지로6가 18-137",
    "doroDetailAddress": "장충단로 249-10, 2층 (을지로6가)",
    "category": "KOREAN_FOOD",
    "restaurantTel": "",
    "lon": 200614.497822789,
    "lat": 451667.793301393,
    "ratingAverage": 4.5, ✔️
    "rating": [
        {
            "ratingId": 2,
            "memberId": 1,
            "restaurantId": "3010000-101-2023-00540",
            "score": 4,
            "content": "다음에도 또 올래요",
            "createAt": "2024-08-30T14:22:53.246222"
        },
        {
            "ratingId": 1,
            "memberId": 1,
            "restaurantId": "3010000-101-2023-00540",
            "score": 5,
            "content": "다음에도 또 올래요",
            "createAt": "2024-08-30T14:22:45.710772"
        }
    ]
}
```

## 🍚 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
- 레스토랑 엔티티와, 상세보기 서비스 수정했는데 혹시 문제 생기면 말씀해주세요!