### PR TITLE
[FIX] 회원가입 시 비밀번호 암호화 기능 수정

### DIFF
--- a/src/main/java/com/lucky/around/meal/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/lucky/around/meal/common/security/filter/JwtAuthenticationFilter.java
@@ -91,6 +91,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
       FilterChain chain,
       Authentication authResult)
       throws IOException, ServletException {
+
     // 인증 객체를 이용해 jwt 생성
     JwtRecord jwtRecord = jwtProvider.getLoginToken(authResult);
     // accessToken은 헤더에 저장

--- a/src/main/java/com/lucky/around/meal/common/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/lucky/around/meal/common/security/filter/JwtAuthorizationFilter.java
@@ -43,6 +43,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
       throws ServletException, IOException {
     // request에서 accessToken 찾고 검증
     String accessToken = jwtProvider.validateToken(request);
+
     if (accessToken != null) {
       try {
         // accessToken을 사용해서 인증객체 등록
@@ -53,9 +54,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         throw new AuthenticationException(
             SecurityExceptionType.REQUIRED_AUTHENTICATION.getMessage()) {};
       }
-    } else {
-      throw new AuthenticationException(
-          SecurityExceptionType.REQUIRED_AUTHENTICATION.getMessage()) {};
     }
     filterChain.doFilter(request, response);
   }

--- a/src/main/java/com/lucky/around/meal/controller/record/RegisterRecord.java
+++ b/src/main/java/com/lucky/around/meal/controller/record/RegisterRecord.java
@@ -5,10 +5,10 @@ import com.lucky.around.meal.entity.enums.MemberRole;
 
 public record RegisterRecord(String memberName, String password, String email) {
 
-  public Member toMember() {
+  public Member toMember(String password) {
     return Member.builder()
         .memberName(memberName())
-        .password(password())
+        .password(password)
         .email(email())
         .lat(0)
         .lon(0)

--- a/src/main/java/com/lucky/around/meal/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/lucky/around/meal/exception/CustomExceptionHandler.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
+import com.lucky.around.meal.exception.exceptionType.SecurityExceptionType;
+
 import lombok.extern.slf4j.Slf4j;
 
 @RestControllerAdvice
@@ -85,7 +87,11 @@ public class CustomExceptionHandler {
   // Spring Security 인증, 인가 관련 예외 처리
   @ExceptionHandler(AuthenticationException.class)
   public ResponseEntity<String> handleAuthenticationException(AuthenticationException ex) {
-    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
+    String message = ex.getMessage();
+    if (ex.getMessage().equals("Full authentication is required to access this resource")) {
+      message = SecurityExceptionType.REQUIRED_AUTHENTICATION.getMessage();
+    }
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(message);
   }
 
   // Spring Security 권한 관련 예외 처리

--- a/src/main/java/com/lucky/around/meal/service/MemberService.java
+++ b/src/main/java/com/lucky/around/meal/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.lucky.around.meal.service;
 
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.lucky.around.meal.common.security.details.PrincipalDetails;
@@ -20,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MemberService {
 
   private final MemberRepository memberRepository;
+  private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
   // 계정명 중복 검증
   public void isExistInDB(RegisterRecord registerRecord) {
@@ -33,8 +35,10 @@ public class MemberService {
 
   // 회원가입
   public void signUp(RegisterRecord registerRecord) {
+    // 비밀번호 암호화
+    String password = bCryptPasswordEncoder.encode(registerRecord.password());
     // RegisterRecord 를 Member 엔티티로 변환
-    Member member = registerRecord.toMember();
+    Member member = registerRecord.toMember(password);
     // DB 저장
     memberRepository.save(member);
   }


### PR DESCRIPTION
## 🍚 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #59

## 🍚 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 회원가입 시 비밀번호를 암호화해서 저장합니다.

## 🍚 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 회원가입 성공

![회원가입 성공](https://github.com/user-attachments/assets/25eb1569-373e-4dab-9f3c-d15f4a44ba15)

- 회원가입 성공(DB)

![회원가입 성공 db](https://github.com/user-attachments/assets/1915e81a-00d9-4085-87d0-7759e63bbc77)

- 회원가입 실패(계정명 중복)

![회원가입 실패](https://github.com/user-attachments/assets/128cbaac-f5cf-4254-8207-a973ef45a88c)

## 🍚 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
- 