### PR TITLE
[REFACTOR] 평가 생성 시 로그인 정보 요청 추가

### DIFF
--- a/src/main/java/com/lucky/around/meal/controller/RatingController.java
+++ b/src/main/java/com/lucky/around/meal/controller/RatingController.java
@@ -3,17 +3,23 @@ package com.lucky.around.meal.controller;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.lucky.around.meal.common.security.details.PrincipalDetails;
 import com.lucky.around.meal.controller.request.RatingRequestDto;
 import com.lucky.around.meal.controller.response.RatingResponseDto;
+import com.lucky.around.meal.exception.CustomException;
+import com.lucky.around.meal.exception.exceptionType.SecurityExceptionType;
 import com.lucky.around.meal.service.RatingService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequestMapping("/api/rating")
 @RestController
 @RequiredArgsConstructor
@@ -23,8 +29,16 @@ public class RatingController {
 
   @PostMapping
   public ResponseEntity<RatingResponseDto> createRating(
-      @RequestBody @Valid RatingRequestDto requestDto) {
-    RatingResponseDto responseDto = ratingService.createRating(requestDto);
+      @RequestBody @Valid RatingRequestDto requestDto,
+      @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+    if (principalDetails == null) {
+      throw new CustomException(SecurityExceptionType.REQUIRED_AUTHENTICATION);
+    }
+
+    Long memberId = principalDetails.getMemberId();
+    log.info("로그인 멤버 id : " + memberId);
+    RatingResponseDto responseDto = ratingService.createRating(memberId, requestDto);
     return ResponseEntity.ok(responseDto);
   }
 }

--- a/src/main/java/com/lucky/around/meal/controller/request/RatingRequestDto.java
+++ b/src/main/java/com/lucky/around/meal/controller/request/RatingRequestDto.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.Range;
 
 public record RatingRequestDto(
-    Long memberId,
     String restaurantId,
     @Range(min = 0, max = 5, message = "0~5 사이의 숫자만 가능합니다.") Integer score,
     @NotBlank(message = "필수 입력값 입니다.")

--- a/src/main/java/com/lucky/around/meal/service/RatingService.java
+++ b/src/main/java/com/lucky/around/meal/service/RatingService.java
@@ -26,11 +26,11 @@ public class RatingService {
   private final RestaurantRepository restaurantRepository;
 
   @Transactional
-  public RatingResponseDto createRating(RatingRequestDto requestDto) {
+  public RatingResponseDto createRating(Long memberId, RatingRequestDto requestDto) {
 
     Member member =
         memberRepository
-            .findById(requestDto.memberId())
+            .findById(memberId)
             .orElseThrow(() -> new CustomException(MemberExceptionType.NOT_FOUND_MEMBER));
 
     Restaurant restaurant =


### PR DESCRIPTION
## 🍚 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #63 

## 🍚 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 평가 생성 시 로그인 정보를 받아옵니다.
- 로그인 유효성 검사로 인해 RatingReqDto에 memberId를 제거하였습니다.

## 🍚 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

### ✅ 로그인 후 평가 생성
![스크린샷 2024-08-30 215646](https://github.com/user-attachments/assets/df965934-baad-4ef1-9295-3df13a00cd78)
![스크린샷 2024-08-30 221746](https://github.com/user-attachments/assets/55662664-3bf5-4d84-86e1-0d614cc3a21c)
---
### ✅ 로그인 정보가 없을 시 예외 처리
![스크린샷 2024-08-30 223427](https://github.com/user-attachments/assets/69a9ad68-033b-4821-ab03-272bac483608)


## 🍚 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
컨트롤러에서는 로그인 유효성 검사, 서비스 단에서는 비즈니스로직을 처리하는 쪽으로 작성하였습니다.