### PR TITLE
[FEAT] 리프레시 토큰 발급 기능 구현

### DIFF
--- a/src/main/java/com/lucky/around/meal/common/security/details/PrincipalDetails.java
+++ b/src/main/java/com/lucky/around/meal/common/security/details/PrincipalDetails.java
@@ -48,4 +48,8 @@ public class PrincipalDetails implements UserDetails {
   public double getLat() {
     return this.member.getLat();
   }
+
+  public Member getMember() {
+    return member;
+  }
 }

--- a/src/main/java/com/lucky/around/meal/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/lucky/around/meal/common/security/filter/JwtAuthenticationFilter.java
@@ -19,6 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lucky.around.meal.common.security.details.PrincipalDetails;
 import com.lucky.around.meal.common.security.handler.CustomAuthenticationFailureHandler;
 import com.lucky.around.meal.common.security.record.JwtRecord;
 import com.lucky.around.meal.common.security.redis.RefreshToken;
@@ -98,9 +99,10 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     response.setHeader(jwtProvider.accessTokenHeader, jwtProvider.prefix + jwtRecord.accessToken());
     // refreshToken은 쿠키에 저장
     response.addCookie(cookieProvider.createRefreshTokenCookie(jwtRecord.refreshToken()));
-    // redis에 refreshToken 저장
+    // redis에 refreshToken 저장, memberId는 String으로 변환 후 저장
+    long memberId = ((PrincipalDetails) authResult.getPrincipal()).getMemberId();
     refreshTokenRepository.save(
-        new RefreshToken(refreshTokenPrefix + jwtRecord.refreshToken(), authResult.getName()));
+        new RefreshToken(refreshTokenPrefix + jwtRecord.refreshToken(), String.valueOf(memberId)));
 
     response.setStatus(HttpStatus.OK.value());
     response.setContentType("text/plain; charset=UTF-8");

--- a/src/main/java/com/lucky/around/meal/common/security/util/CookieProvider.java
+++ b/src/main/java/com/lucky/around/meal/common/security/util/CookieProvider.java
@@ -66,10 +66,6 @@ public class CookieProvider {
 
   // 리프레시 토큰 담은 쿠키 재발급
   public Cookie reissueRefreshTokenCookie(Optional<Cookie> cookie, String refreshToken) {
-    if (cookie.isPresent()) {
-      return createRefreshTokenCookie(refreshToken);
-    } else {
-      throw new CustomException(SecurityExceptionType.COOKIE_NOT_FOUND);
-    }
+    return createRefreshTokenCookie(refreshToken);
   }
 }

--- a/src/main/java/com/lucky/around/meal/common/security/util/CookieProvider.java
+++ b/src/main/java/com/lucky/around/meal/common/security/util/CookieProvider.java
@@ -46,15 +46,28 @@ public class CookieProvider {
   // 로그아웃 시 리프레시 토큰 삭제
   public Cookie deleteRefreshTokenCookie(HttpServletRequest request) {
     // 리퀘스트에서 refreshToken 빼오기
-    Optional<Cookie> findCookie =
-        Arrays.stream(request.getCookies())
-            .filter(cookie -> cookieName.equals(cookie.getName()))
-            .findFirst();
+    Optional<Cookie> findCookie = getRefreshTokenCookie(request);
     // 토큰 만료기간 0으로 설정
     if (findCookie.isPresent()) {
       Cookie cookie = findCookie.get();
       cookie.setMaxAge(0);
       return cookie;
+    } else {
+      throw new CustomException(SecurityExceptionType.COOKIE_NOT_FOUND);
+    }
+  }
+
+  // 리퀘스트에서 리프레시 토큰 빼오기
+  public Optional<Cookie> getRefreshTokenCookie(HttpServletRequest request) {
+    return Arrays.stream(request.getCookies())
+        .filter(cookie -> cookieName.equals(cookie.getName()))
+        .findFirst();
+  }
+
+  // 리프레시 토큰 담은 쿠키 재발급
+  public Cookie reissueRefreshTokenCookie(Optional<Cookie> cookie, String refreshToken) {
+    if (cookie.isPresent()) {
+      return createRefreshTokenCookie(refreshToken);
     } else {
       throw new CustomException(SecurityExceptionType.COOKIE_NOT_FOUND);
     }

--- a/src/main/java/com/lucky/around/meal/controller/MemberController.java
+++ b/src/main/java/com/lucky/around/meal/controller/MemberController.java
@@ -1,5 +1,8 @@
 package com.lucky.around.meal.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -36,5 +39,12 @@ public class MemberController {
       @AuthenticationPrincipal PrincipalDetails principalDetails) {
     MemberDto memberDto = memberService.getMemberInfo(principalDetails);
     return ResponseEntity.ok(memberDto);
+  }
+
+  @PostMapping("/refresh_token")
+  public ResponseEntity<String> reissueRefreshToken(
+      HttpServletRequest request, HttpServletResponse response) {
+    memberService.reissueRefreshToken(request, response);
+    return ResponseEntity.ok("토큰 재발급이 성공적으로 완료되었습니다.");
   }
 }

--- a/src/main/java/com/lucky/around/meal/service/JwtService.java
+++ b/src/main/java/com/lucky/around/meal/service/JwtService.java
@@ -1,0 +1,77 @@
+package com.lucky.around.meal.service;
+
+import java.util.Optional;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.lucky.around.meal.common.security.record.JwtRecord;
+import com.lucky.around.meal.common.security.redis.RefreshToken;
+import com.lucky.around.meal.common.security.redis.RefreshTokenRepository;
+import com.lucky.around.meal.common.security.util.CookieProvider;
+import com.lucky.around.meal.common.security.util.JwtProvider;
+import com.lucky.around.meal.entity.Member;
+import com.lucky.around.meal.exception.CustomException;
+import com.lucky.around.meal.exception.exceptionType.MemberExceptionType;
+import com.lucky.around.meal.exception.exceptionType.SecurityExceptionType;
+import com.lucky.around.meal.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+  // jwt 관리 클래스
+  private final JwtProvider jwtProvider;
+  // 쿠키 관리 클래스
+  private final CookieProvider cookieProvider;
+  // redis 리포지토리
+  private final RefreshTokenRepository refreshTokenRepository;
+  // Member 리포지토리
+  private final MemberRepository memberRepository;
+
+  // refreshToken 프리픽스
+  @Value("${spring.data.redis.prefix}")
+  String refreshTokenPrefix;
+
+  public void reissueRefreshToken(HttpServletRequest request, HttpServletResponse response) {
+
+    // 리퀘스트에서 refreshToken 빼오기
+    Optional<Cookie> findCookie = cookieProvider.getRefreshTokenCookie(request);
+    if (!findCookie.isPresent()) throw new CustomException(SecurityExceptionType.COOKIE_NOT_FOUND);
+
+    // redis에서 쿠키 값을 이용해 refreshToken 가져오기
+    Optional<RefreshToken> refreshToken =
+        refreshTokenRepository.findById(refreshTokenPrefix + findCookie.get().getValue());
+    if (!refreshToken.isPresent())
+      throw new CustomException(SecurityExceptionType.REFRESHTOKEN_NOT_FOUND);
+
+    // 계정 아이디 찾아오기
+    long memberId = Long.parseLong(refreshToken.get().getMemberId());
+
+    // memberRepository 에서 사용자 정보 가져오기
+    Member findMember =
+        memberRepository
+            .findById(memberId)
+            .orElseThrow(() -> new CustomException(MemberExceptionType.NOT_FOUND_MEMBER));
+
+    // 사용자 정보로 리프레시 토큰, 엑세스 토큰 다시 만들기
+    JwtRecord reissueToken = jwtProvider.getReissueToken(findMember);
+
+    // accessToken은 헤더에 저장
+    response.setHeader(
+        jwtProvider.accessTokenHeader, jwtProvider.prefix + reissueToken.accessToken());
+    // refreshToken은 쿠키에 저장
+    response.addCookie(cookieProvider.createRefreshTokenCookie(reissueToken.refreshToken()));
+    // redis에 refreshToken 저장, memberId는 String으로 변환 후 저장
+    refreshTokenRepository.save(
+        new RefreshToken(
+            refreshTokenPrefix + reissueToken.refreshToken(), String.valueOf(memberId)));
+  }
+}

--- a/src/main/java/com/lucky/around/meal/service/MemberService.java
+++ b/src/main/java/com/lucky/around/meal/service/MemberService.java
@@ -1,5 +1,8 @@
 package com.lucky.around.meal.service;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +25,7 @@ public class MemberService {
 
   private final MemberRepository memberRepository;
   private final BCryptPasswordEncoder bCryptPasswordEncoder;
+  private final JwtService jwtService;
 
   // 계정명 중복 검증
   public void isExistInDB(RegisterRecord registerRecord) {
@@ -55,5 +59,10 @@ public class MemberService {
             .findById(loginMember.getMemberId())
             .orElseThrow(() -> new CustomException(MemberExceptionType.NOT_FOUND_MEMBER));
     return new MemberDto(newMember);
+  }
+
+  // 리프레시 토큰으로 액세스 토큰, 리프레시 토큰 재발급
+  public void reissueRefreshToken(HttpServletRequest request, HttpServletResponse response) {
+    jwtService.reissueRefreshToken(request, response);
   }
 }


### PR DESCRIPTION
## 🍚 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #64

## 🍚 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 리프레시 토큰을 이용하여 엑세스 토큰, 리프레시 토큰 재발급하는 기능을 구현했습니다.

## 🍚 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 리프레시 토큰 재발급 전

![리프레시토큰 재발급-재발급 전](https://github.com/user-attachments/assets/f7471e94-a163-4ec6-8be3-c349e6ecbed5)

- 리프레시 토큰 재발급 성공(응답)

![리프레시토큰 재발급 성공-응답](https://github.com/user-attachments/assets/56eb1e04-69af-4c94-83f1-2c6a3f3353f1)

- 리프레시 토큰 재발급 후

![리프레시토큰 재발급 성공-쿠키](https://github.com/user-attachments/assets/5043af63-d318-49b6-a6c5-b3d54a890380)

## 🍚 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
- 