### PR TITLE
[FEAT] 사용자 설정 업데이트

### DIFF
--- a/src/main/java/com/lucky/around/meal/common/redis/RedisRepository.java
+++ b/src/main/java/com/lucky/around/meal/common/redis/RedisRepository.java
@@ -1,11 +1,16 @@
 package com.lucky.around.meal.common.redis;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.geo.Point;
 import org.springframework.data.redis.core.GeoOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
+
+import com.lucky.around.meal.exception.CustomException;
+import com.lucky.around.meal.exception.exceptionType.MemberExceptionType;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,5 +24,19 @@ public class RedisRepository {
     GeoOperations<String, String> geoOps = redisTemplate.opsForGeo();
     geoOps.add(key, new Point(lat, lon), String.valueOf(memberId));
     redisTemplate.expire(key, 15, TimeUnit.MINUTES);
+  }
+
+  public Point getRealTimeLocation(String key, Long memberId) {
+    GeoOperations<String, String> geoOps = redisTemplate.opsForGeo();
+    List<Point> positions = geoOps.position(key, String.valueOf(memberId));
+
+    return getFirstPositionOrThrow(positions);
+  }
+
+  private Point getFirstPositionOrThrow(List<Point> positions) {
+    return Optional.ofNullable(positions)
+        .filter(list -> !list.isEmpty())
+        .map(list -> list.get(0))
+        .orElseThrow(() -> new CustomException(MemberExceptionType.REALTIME_LOCATION_NOT_FOUND));
   }
 }

--- a/src/main/java/com/lucky/around/meal/common/redis/RedisRepository.java
+++ b/src/main/java/com/lucky/around/meal/common/redis/RedisRepository.java
@@ -1,0 +1,23 @@
+package com.lucky.around.meal.common.redis;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.core.GeoOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisRepository {
+
+  private final StringRedisTemplate redisTemplate;
+
+  public void saveRealTimeLocation(String key, double lat, double lon, Long memberId) {
+    GeoOperations<String, String> geoOps = redisTemplate.opsForGeo();
+    geoOps.add(key, new Point(lat, lon), String.valueOf(memberId));
+    redisTemplate.expire(key, 15, TimeUnit.MINUTES);
+  }
+}

--- a/src/main/java/com/lucky/around/meal/controller/LocationController.java
+++ b/src/main/java/com/lucky/around/meal/controller/LocationController.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.lucky.around.meal.controller.request.*;
+import com.lucky.around.meal.controller.request.StaticLocationRequestDto;
 import com.lucky.around.meal.controller.response.*;
 import com.lucky.around.meal.service.*;
 
@@ -26,5 +27,11 @@ public class LocationController {
   public ResponseEntity<LocationResponseDto> getMemberLocation() {
     LocationResponseDto location = service.getMemberLocationToTrans();
     return ResponseEntity.ok(location);
+  }
+
+  @PatchMapping("/static")
+  public ResponseEntity<Void> updateStaticLocation(@RequestBody StaticLocationRequestDto request) {
+    service.updateStaticLocation(request);
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/lucky/around/meal/controller/LocationController.java
+++ b/src/main/java/com/lucky/around/meal/controller/LocationController.java
@@ -1,0 +1,30 @@
+package com.lucky.around.meal.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.lucky.around.meal.controller.request.*;
+import com.lucky.around.meal.controller.response.*;
+import com.lucky.around.meal.service.*;
+
+import lombok.RequiredArgsConstructor;
+
+@RequestMapping("/api/locations")
+@RestController
+@RequiredArgsConstructor
+public class LocationController {
+
+  private final LocationService service;
+
+  @PostMapping("/real-time")
+  public ResponseEntity<Void> saveMemberLocation(@RequestBody MemberLocationRequestDto request) {
+    service.saveMemberLocation(request);
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/real-time")
+  public ResponseEntity<LocationResponseDto> getMemberLocation() {
+    LocationResponseDto location = service.getMemberLocationToTrans();
+    return ResponseEntity.ok(location);
+  }
+}

--- a/src/main/java/com/lucky/around/meal/controller/LocationController.java
+++ b/src/main/java/com/lucky/around/meal/controller/LocationController.java
@@ -34,4 +34,10 @@ public class LocationController {
     service.updateStaticLocation(request);
     return ResponseEntity.ok().build();
   }
+
+  @GetMapping("/static")
+  public ResponseEntity<StaticLocationResponseDto> getStaticLocation() {
+    StaticLocationResponseDto location = service.getStaticLocation();
+    return ResponseEntity.ok(location);
+  }
 }

--- a/src/main/java/com/lucky/around/meal/controller/request/MemberLocationRequestDto.java
+++ b/src/main/java/com/lucky/around/meal/controller/request/MemberLocationRequestDto.java
@@ -1,3 +1,3 @@
 package com.lucky.around.meal.controller.request;
 
-public record MemberLocationRequestDto(Double lat, Double lon) {}
+public record MemberLocationRequestDto(Double lon, Double lat) {}

--- a/src/main/java/com/lucky/around/meal/controller/request/MemberLocationRequestDto.java
+++ b/src/main/java/com/lucky/around/meal/controller/request/MemberLocationRequestDto.java
@@ -1,0 +1,3 @@
+package com.lucky.around.meal.controller.request;
+
+public record MemberLocationRequestDto(Double lat, Double lon) {}

--- a/src/main/java/com/lucky/around/meal/controller/request/StaticLocationRequestDto.java
+++ b/src/main/java/com/lucky/around/meal/controller/request/StaticLocationRequestDto.java
@@ -1,3 +1,3 @@
 package com.lucky.around.meal.controller.request;
 
-public record StaticLocationRequestDto(double lat, double lon) {}
+public record StaticLocationRequestDto(double lon, double lat) {}

--- a/src/main/java/com/lucky/around/meal/controller/request/StaticLocationRequestDto.java
+++ b/src/main/java/com/lucky/around/meal/controller/request/StaticLocationRequestDto.java
@@ -1,0 +1,3 @@
+package com.lucky.around.meal.controller.request;
+
+public record StaticLocationRequestDto(double lat, double lon) {}

--- a/src/main/java/com/lucky/around/meal/controller/response/LocationResponseDto.java
+++ b/src/main/java/com/lucky/around/meal/controller/response/LocationResponseDto.java
@@ -1,0 +1,3 @@
+package com.lucky.around.meal.controller.response;
+
+public record LocationResponseDto(double lat, double lon) {}

--- a/src/main/java/com/lucky/around/meal/controller/response/LocationResponseDto.java
+++ b/src/main/java/com/lucky/around/meal/controller/response/LocationResponseDto.java
@@ -1,3 +1,3 @@
 package com.lucky.around.meal.controller.response;
 
-public record LocationResponseDto(double lat, double lon) {}
+public record LocationResponseDto(double lon, double lat) {}

--- a/src/main/java/com/lucky/around/meal/controller/response/StaticLocationResponseDto.java
+++ b/src/main/java/com/lucky/around/meal/controller/response/StaticLocationResponseDto.java
@@ -1,3 +1,3 @@
 package com.lucky.around.meal.controller.response;
 
-public record StaticLocationResponseDto(double lat, double lon) {}
+public record StaticLocationResponseDto(double lon, double lat) {}

--- a/src/main/java/com/lucky/around/meal/controller/response/StaticLocationResponseDto.java
+++ b/src/main/java/com/lucky/around/meal/controller/response/StaticLocationResponseDto.java
@@ -1,0 +1,3 @@
+package com.lucky.around.meal.controller.response;
+
+public record StaticLocationResponseDto(double lat, double lon) {}

--- a/src/main/java/com/lucky/around/meal/entity/Member.java
+++ b/src/main/java/com/lucky/around/meal/entity/Member.java
@@ -1,5 +1,8 @@
 package com.lucky.around.meal.entity;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 import jakarta.persistence.*;
 
 import com.lucky.around.meal.entity.enums.MemberRole;
@@ -38,7 +41,13 @@ public class Member {
   private double lat;
 
   public void updateLocation(double lon, double lat) {
-    this.lon = lon;
-    this.lat = lat;
+    this.lon = round(lon, 6);
+    this.lat = round(lat, 6);
+  }
+
+  private double round(double value, int decimalPlaces) {
+    BigDecimal bd = new BigDecimal(value);
+    bd = bd.setScale(decimalPlaces, RoundingMode.HALF_UP);
+    return bd.doubleValue();
   }
 }

--- a/src/main/java/com/lucky/around/meal/entity/Member.java
+++ b/src/main/java/com/lucky/around/meal/entity/Member.java
@@ -32,13 +32,13 @@ public class Member {
   private MemberRole role;
 
   @Column(nullable = true)
-  private double lat;
-
-  @Column(nullable = true)
   private double lon;
 
-  public void updateLocation(double lat, double lon) {
-    this.lat = lat;
+  @Column(nullable = true)
+  private double lat;
+
+  public void updateLocation(double lon, double lat) {
     this.lon = lon;
+    this.lat = lat;
   }
 }

--- a/src/main/java/com/lucky/around/meal/entity/Member.java
+++ b/src/main/java/com/lucky/around/meal/entity/Member.java
@@ -36,4 +36,9 @@ public class Member {
 
   @Column(nullable = true)
   private double lon;
+
+  public void updateLocation(double lat, double lon) {
+    this.lat = lat;
+    this.lon = lon;
+  }
 }

--- a/src/main/java/com/lucky/around/meal/exception/exceptionType/MemberExceptionType.java
+++ b/src/main/java/com/lucky/around/meal/exception/exceptionType/MemberExceptionType.java
@@ -9,7 +9,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum MemberExceptionType implements ExceptionType {
-  NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
+  MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 회원 정보를 찾을 수 없습니다."),
+  REALTIME_LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "회원의 실시간 위치 정보를 찾을 수 없습니다."),
+  LOCATION_NOT_FOUNT(HttpStatus.NOT_FOUND, "회원의 위치 정보를 찾을 수 없습니다."),
+  ;
 
   private final HttpStatus status;
   private final String message;

--- a/src/main/java/com/lucky/around/meal/service/JwtService.java
+++ b/src/main/java/com/lucky/around/meal/service/JwtService.java
@@ -53,7 +53,7 @@ public class JwtService {
     Member findMember = getMember(refreshToken.get().getMemberId());
 
     // 토큰 재발급 후 헤더, 쿠키, redis에 토큰 저장
-    reissueToken(findMember,response);
+    reissueToken(findMember, response);
   }
 
   // 리퀘스트에서 refreshToken 빼오기
@@ -66,7 +66,7 @@ public class JwtService {
   // redis에서 쿠키 값을 이용해 refreshToken 가져오기
   private Optional<RefreshToken> getRefreshToken(Optional<Cookie> findCookie) {
     Optional<RefreshToken> refreshToken =
-            refreshTokenRepository.findById(refreshTokenPrefix + findCookie.get().getValue());
+        refreshTokenRepository.findById(refreshTokenPrefix + findCookie.get().getValue());
     if (!refreshToken.isPresent())
       throw new CustomException(SecurityExceptionType.REFRESHTOKEN_NOT_FOUND);
     return refreshToken;
@@ -79,9 +79,9 @@ public class JwtService {
 
     // memberRepository 에서 사용자 정보 가져오기
     Member findMember =
-            memberRepository
-                    .findById(savedMemberId)
-                    .orElseThrow(() -> new CustomException(MemberExceptionType.NOT_FOUND_MEMBER));
+        memberRepository
+            .findById(savedMemberId)
+            .orElseThrow(() -> new CustomException(MemberExceptionType.MEMBER_NOT_FOUND));
     return findMember;
   }
 
@@ -92,12 +92,13 @@ public class JwtService {
 
     // accessToken은 헤더에 저장
     response.setHeader(
-            jwtProvider.accessTokenHeader, jwtProvider.prefix + reissueToken.accessToken());
+        jwtProvider.accessTokenHeader, jwtProvider.prefix + reissueToken.accessToken());
     // refreshToken은 쿠키에 저장
     response.addCookie(cookieProvider.createRefreshTokenCookie(reissueToken.refreshToken()));
     // redis에 refreshToken 저장, memberId는 String으로 변환 후 저장
     refreshTokenRepository.save(
-            new RefreshToken(
-                    refreshTokenPrefix + reissueToken.refreshToken(), String.valueOf(findMember.getMemberId())));
+        new RefreshToken(
+            refreshTokenPrefix + reissueToken.refreshToken(),
+            String.valueOf(findMember.getMemberId())));
   }
 }

--- a/src/main/java/com/lucky/around/meal/service/LocationService.java
+++ b/src/main/java/com/lucky/around/meal/service/LocationService.java
@@ -24,35 +24,30 @@ public class LocationService {
   private final RedisRepository redis;
   private final MemberRepository memberRepository;
 
-  // Redis에 실시간 위치 정보 저장
   public void saveMemberLocation(MemberLocationRequestDto request) {
     String key = generateRedisKey(getCurrentMemberId());
-    redis.saveRealTimeLocation(key, request.lat(), request.lon(), getCurrentMemberId());
+    redis.saveRealTimeLocation(key, request.lon(), request.lat(), getCurrentMemberId());
   }
 
-  // Redis에서 실시간 위치 정보 조회
   public Point getMemberLocation() {
     String key = generateRedisKey(getCurrentMemberId());
     return redis.getRealTimeLocation(key, getCurrentMemberId());
   }
 
-  // 회원의 정적인 위치 정보 업데이트
   @Transactional
   public void updateStaticLocation(StaticLocationRequestDto request) {
     Member member = findMemberById(getCurrentMemberId());
     member.updateLocation(request.lon(), request.lat());
   }
 
-  // 회원의 정적인 위치 정보 조회
   public StaticLocationResponseDto getStaticLocation() {
     Member member = findMemberById(getCurrentMemberId());
-    return new StaticLocationResponseDto(member.getLat(), member.getLon());
+    return new StaticLocationResponseDto(member.getLon(), member.getLat());
   }
 
-  // 회원 실시간 위치 정보 DTO 변환
   public LocationResponseDto getMemberLocationToTrans() {
     Point redisPoint = getMemberLocation();
-    return new LocationResponseDto(redisPoint.getY(), redisPoint.getX());
+    return new LocationResponseDto(redisPoint.getX(), redisPoint.getY());
   }
 
   private String generateRedisKey(Long memberId) {

--- a/src/main/java/com/lucky/around/meal/service/LocationService.java
+++ b/src/main/java/com/lucky/around/meal/service/LocationService.java
@@ -1,0 +1,51 @@
+package com.lucky.around.meal.service;
+
+import org.springframework.data.geo.Point;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import com.lucky.around.meal.common.redis.RedisRepository;
+import com.lucky.around.meal.common.security.details.PrincipalDetails;
+import com.lucky.around.meal.controller.request.*;
+import com.lucky.around.meal.controller.response.*;
+import com.lucky.around.meal.entity.*;
+import com.lucky.around.meal.repository.*;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LocationService {
+
+  private final RedisRepository redis;
+  private final MemberRepository memberRepository;
+
+  // Redis에 실시간 위치 정보 저장
+  public void saveMemberLocation(MemberLocationRequestDto request) {
+    String key = generateRedisKey(getCurrentMemberId());
+    redis.saveRealTimeLocation(key, request.lat(), request.lon(), getCurrentMemberId());
+  }
+
+  // Redis에서 실시간 위치 정보 조회
+  public Point getMemberLocation() {
+    String key = generateRedisKey(getCurrentMemberId());
+    return redis.getRealTimeLocation(key, getCurrentMemberId());
+  }
+
+  // 회원 실시간 위치 정보 DTO 변환
+  public LocationResponseDto getMemberLocationToTrans() {
+    Point redisPoint = getMemberLocation();
+    return new LocationResponseDto(redisPoint.getY(), redisPoint.getX());
+  }
+
+  private String generateRedisKey(Long memberId) {
+    return "location:" + memberId;
+  }
+
+  private Long getCurrentMemberId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    PrincipalDetails principal = (PrincipalDetails) authentication.getPrincipal();
+    return principal.getMemberId();
+  }
+}

--- a/src/main/java/com/lucky/around/meal/service/LocationService.java
+++ b/src/main/java/com/lucky/around/meal/service/LocationService.java
@@ -43,6 +43,12 @@ public class LocationService {
     member.updateLocation(request.lon(), request.lat());
   }
 
+  // 회원의 정적인 위치 정보 조회
+  public StaticLocationResponseDto getStaticLocation() {
+    Member member = findMemberById(getCurrentMemberId());
+    return new StaticLocationResponseDto(member.getLat(), member.getLon());
+  }
+
   // 회원 실시간 위치 정보 DTO 변환
   public LocationResponseDto getMemberLocationToTrans() {
     Point redisPoint = getMemberLocation();

--- a/src/main/java/com/lucky/around/meal/service/MemberService.java
+++ b/src/main/java/com/lucky/around/meal/service/MemberService.java
@@ -54,7 +54,7 @@ public class MemberService {
     Member newMember =
         memberRepository
             .findById(principalDetails.getMemberId())
-            .orElseThrow(() -> new CustomException(MemberExceptionType.NOT_FOUND_MEMBER));
+            .orElseThrow(() -> new CustomException(MemberExceptionType.MEMBER_NOT_FOUND));
     return new MemberDto(newMember);
   }
 

--- a/src/main/java/com/lucky/around/meal/service/RatingService.java
+++ b/src/main/java/com/lucky/around/meal/service/RatingService.java
@@ -31,7 +31,7 @@ public class RatingService {
     Member member =
         memberRepository
             .findById(memberId)
-            .orElseThrow(() -> new CustomException(MemberExceptionType.NOT_FOUND_MEMBER));
+            .orElseThrow(() -> new CustomException(MemberExceptionType.MEMBER_NOT_FOUND));
 
     Restaurant restaurant =
         restaurantRepository


### PR DESCRIPTION
## 🍚 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #21 

## 🍚 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 실시간 회원 위치 정보 레디스 저장/조회
- 정적인 회원 위치 정보 DB 저장/조회
- 위치 정보 GIS 표준적인 접근 방식 사용

## 🍚 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 실시간 회원 위치 정보 Redis 저장
![image](https://github.com/user-attachments/assets/afb33679-9dd9-44b2-8994-00a8cfbc053d)
- 실시간 회원 위치 정보 Redis 조회
![image](https://github.com/user-attachments/assets/6c030090-ccef-4ef7-a5f9-a774b73c51cf)
- 정적인 회원 위치 정보 DB 저장
![image](https://github.com/user-attachments/assets/78d32517-ee8f-4085-8e69-e5defb9afd3f)
- 정적인 회원 위치 정보 DB 조회
![image](https://github.com/user-attachments/assets/32613ba6-b2a8-4b67-bee4-c9712353eb86)



## 🍚 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
- Redis Geo 기능 사용으로 인한 StringRedisTemplate의 GeoOperations 활용
- GIS 표준 적용 (경도, 위도)
- Redis Geo API 는 WGS84 좌표계를 사용함
- 소수점 6자리의 값을 사용할 경우, 약 10cm정도의 오차를 가지며, 대부분의 위치 기반 서비스에서는 정확한 결과를 얻을 수 있음
- Redis를 통해 저장시키고, 조회시킨 값의 오차는 크게 문제되지 않는 값임