### PR TITLE
[FEAT] 시군구 목록 조회 API 고도화

### DIFF
--- a/src/main/java/com/lucky/around/meal/Application.java
+++ b/src/main/java/com/lucky/around/meal/Application.java
@@ -2,8 +2,10 @@ package com.lucky.around.meal;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableCaching
 @SpringBootApplication
 @EnableScheduling
 public class Application {

--- a/src/main/java/com/lucky/around/meal/common/config/CacheConfig.java
+++ b/src/main/java/com/lucky/around/meal/common/config/CacheConfig.java
@@ -1,0 +1,49 @@
+package com.lucky.around.meal.common.config;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class CacheConfig {
+
+  private final RedisConnectionFactory redisConnectionFactory;
+
+  public CacheConfig(RedisConnectionFactory redisConnectionFactory) {
+    this.redisConnectionFactory = redisConnectionFactory;
+  }
+
+  @Bean
+  public CacheManager cacheManager() {
+    // Redis 캐시 기본 설정 defaultConfiguration
+    RedisCacheConfiguration defaultConfiguration =
+        RedisCacheConfiguration.defaultCacheConfig()
+            // 캐시 키 직렬화, JSON 형식 직렬화
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new GenericJackson2JsonRedisSerializer()));
+
+    // 특정 캐시 관리 (MAP)
+    Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+    // regionList - 시군구 목록 조회 캐싱 TEST 1분
+    cacheConfigurations.put("regionList", defaultConfiguration.entryTtl(Duration.ofMinutes(1)));
+
+    return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
+        .cacheDefaults(defaultConfiguration)
+        .withInitialCacheConfigurations(cacheConfigurations)
+        .build();
+  }
+}

--- a/src/main/java/com/lucky/around/meal/common/config/CacheConfig.java
+++ b/src/main/java/com/lucky/around/meal/common/config/CacheConfig.java
@@ -38,8 +38,8 @@ public class CacheConfig {
 
     // 특정 캐시 관리 (MAP)
     Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
-    // regionList - 시군구 목록 조회 캐싱 TEST 1분
-    cacheConfigurations.put("regionList", defaultConfiguration.entryTtl(Duration.ofMinutes(1)));
+    // regionList - 시군구 목록 조회 캐싱 TEST 10분
+    cacheConfigurations.put("regionList", defaultConfiguration.entryTtl(Duration.ofMinutes(10)));
 
     return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
         .cacheDefaults(defaultConfiguration)

--- a/src/main/java/com/lucky/around/meal/service/RegionService.java
+++ b/src/main/java/com/lucky/around/meal/service/RegionService.java
@@ -3,6 +3,7 @@ package com.lucky.around.meal.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import com.lucky.around.meal.controller.record.RegionRecord;
@@ -19,7 +20,11 @@ public class RegionService {
   private final RegionRepository regionRepository;
 
   // 시군구 전체 조회
+  // value = "regionList" [캐시], key = redis의 key 값
+  // ex) regionList::allRegions
+  @Cacheable(value = "regionList", key = "'allRegions'")
   public List<RegionRecord> getAllRegionList() {
+    log.info("Fetching all regions from the database");
     return regionRepository.findAll().stream()
         .map(RegionRecord::fromEntity)
         .collect(Collectors.toList());


### PR DESCRIPTION
## 🍚 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #81 

## 🍚 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
**프로젝트 요구사항**
- 모든 유저가 사용하지만, 긴시간 변동이 없는 성격을 지닌 데이터이기에, 캐싱을 진행한다.
- 데이터 특성상 만료 기간은 없거나 일반 API 보다 길어도 됩니다.
1. CacheConfig 파일 추가 [common / confing]
2. 시군구 목록 최초 조회 시 redis 연동하여 저장. 캐싱처리 완료

## 🍚 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
### **1. 캐시 처리 전 DB를 통해 계속 조회 / 반복 호출**

![스크린샷 2024-09-01 151319](https://github.com/user-attachments/assets/debb0120-0c66-407c-bf98-41d5e7177619)
![스크린샷 2024-09-01 220804](https://github.com/user-attachments/assets/c239be09-08da-4654-a4f6-d61fd09460cd)

### **2. redis 캐시 처리 후 - 반복 호출 시에도 DB 메서드 최초 한번만 호출(redis를 통한 조회)**

![스크린샷 2024-09-01 233222](https://github.com/user-attachments/assets/6867eee7-8579-49ba-8376-179cb5f28162)
![스크린샷 2024-09-01 171128](https://github.com/user-attachments/assets/1b575362-fdb5-41f6-b535-0e30db4e783d)

### **3. 응답 시간 차이 (약 30번 조회)
- 캐시 처리 전

![스크린샷 2024-09-01 230849](https://github.com/user-attachments/assets/7424ea32-c3b8-42ae-8f0b-ff2ef3516262)

- 캐시 처리 후

![스크린샷 2024-09-01 230943](https://github.com/user-attachments/assets/3df3742f-8e82-4c2a-b7b0-0416a1fa7b11)

최초 응답 시간은 캐시 처리 후가 더 걸리나, 반복 조회 해봤을 때는 약 2~3배 정도 빠른 응답시간을 보임



## 🍚 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
현재는 테스트 단계로 캐시 만료시간을 10분으로 설정하였습니다.
테스트 코드까지 다 작성 후 365일로 바꿀 예정입니다!