### PR TITLE
[FEAT] 맛집 상세정보 고도화(조회수 기준)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ dependencies {
 	// webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	// Jackson
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.2'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/lucky/around/meal/cache/service/ViewCountService.java
+++ b/src/main/java/com/lucky/around/meal/cache/service/ViewCountService.java
@@ -1,0 +1,25 @@
+package com.lucky.around.meal.cache.service;
+
+import org.springframework.data.redis.core.*;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ViewCountService {
+
+  private final StringRedisTemplate redisTemplate;
+  private static final String VIEW_COUNT_KEY_PREFIX = "viewCount:";
+
+  private String buildKey(String restaurantId) {
+    return VIEW_COUNT_KEY_PREFIX + restaurantId;
+  }
+
+  // 조회수 증가
+  public void incrementViewCount(String restaurantId) {
+    String key = buildKey(restaurantId);
+    ValueOperations<String, String> ops = redisTemplate.opsForValue();
+    ops.increment(key, 1);
+  }
+}

--- a/src/main/java/com/lucky/around/meal/cache/service/ViewCountService.java
+++ b/src/main/java/com/lucky/around/meal/cache/service/ViewCountService.java
@@ -22,4 +22,12 @@ public class ViewCountService {
     ValueOperations<String, String> ops = redisTemplate.opsForValue();
     ops.increment(key, 1);
   }
+
+  // 특정 맛집의 조회수 가져오기
+  public Long getViewCount(String restaurantId) {
+    String key = buildKey(restaurantId);
+    ValueOperations<String, String> ops = redisTemplate.opsForValue();
+    String value = ops.get(key);
+    return value != null ? Long.parseLong(value) : 0L;
+  }
 }

--- a/src/main/java/com/lucky/around/meal/cache/service/ViewCountService.java
+++ b/src/main/java/com/lucky/around/meal/cache/service/ViewCountService.java
@@ -1,6 +1,9 @@
 package com.lucky.around.meal.cache.service;
 
+import java.util.Set;
+
 import org.springframework.data.redis.core.*;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -29,5 +32,16 @@ public class ViewCountService {
     ValueOperations<String, String> ops = redisTemplate.opsForValue();
     String value = ops.get(key);
     return value != null ? Long.parseLong(value) : 0L;
+  }
+
+  // 조회수 초기화
+  @Scheduled(cron = "0 0 11,17 * * ?") // 매일 오전 11시와 오후 5시에 실행
+  public void resetViewCounts() {
+    Set<String> keys = redisTemplate.keys(VIEW_COUNT_KEY_PREFIX + "*");
+    if (keys != null) {
+      for (String key : keys) {
+        redisTemplate.opsForValue().set(key, "0");
+      }
+    }
   }
 }

--- a/src/main/java/com/lucky/around/meal/common/config/CacheConfig.java
+++ b/src/main/java/com/lucky/around/meal/common/config/CacheConfig.java
@@ -48,6 +48,8 @@ public class CacheConfig {
     Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
     // regionList - 시군구 목록 조회 캐싱 TEST 10분
     cacheConfigurations.put("regionList", defaultConfiguration.entryTtl(Duration.ofMinutes(10)));
+    // restaurantDetail - 맛집 상세 정보 캐싱 1시간
+    cacheConfigurations.put("restaurantDetail", defaultConfiguration.entryTtl(Duration.ofHours(1)));
 
     return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
         .cacheDefaults(defaultConfiguration)

--- a/src/main/java/com/lucky/around/meal/common/config/CacheConfig.java
+++ b/src/main/java/com/lucky/around/meal/common/config/CacheConfig.java
@@ -1,26 +1,34 @@
 package com.lucky.around.meal.common.config;
 
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import org.springframework.cache.CacheManager;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.context.annotation.*;
+import org.springframework.data.redis.cache.*;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.serializer.*;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
+@RequiredArgsConstructor
 public class CacheConfig {
 
   private final RedisConnectionFactory redisConnectionFactory;
 
-  public CacheConfig(RedisConnectionFactory redisConnectionFactory) {
-    this.redisConnectionFactory = redisConnectionFactory;
+  @Bean
+  public ObjectMapper objectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.registerModule(new JavaTimeModule());
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    return mapper;
   }
 
   @Bean

--- a/src/main/java/com/lucky/around/meal/controller/RestaurantController.java
+++ b/src/main/java/com/lucky/around/meal/controller/RestaurantController.java
@@ -31,6 +31,15 @@ public class RestaurantController {
     return ResponseEntity.ok(restaurantDetail);
   }
 
+  // 조회수가 N개 이상인 맛집 상세 정보 조회
+  @GetMapping("/high-view-count")
+  public ResponseEntity<List<RestaurantDetailResponseDto>> getRestaurantsWithMinViews(
+      @RequestParam long minViews) {
+    List<RestaurantDetailResponseDto> restaurants =
+        restaurantService.getRestaurantsWithMinViews(minViews);
+    return ResponseEntity.ok(restaurants);
+  }
+
   @GetMapping()
   public List<GetRestaurantsDto> findRestaurantsWithinRange(
       final @RequestParam double lat,

--- a/src/main/java/com/lucky/around/meal/controller/RestaurantController.java
+++ b/src/main/java/com/lucky/around/meal/controller/RestaurantController.java
@@ -6,9 +6,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.lucky.around.meal.cache.service.ViewCountService;
 import com.lucky.around.meal.controller.dto.GetRestaurantsDto;
 import com.lucky.around.meal.controller.response.RestaurantDetailResponseDto;
-import com.lucky.around.meal.repository.RestaurantRepository;
 import com.lucky.around.meal.service.RestaurantService;
 
 import lombok.RequiredArgsConstructor;
@@ -19,13 +19,15 @@ import lombok.RequiredArgsConstructor;
 public class RestaurantController {
 
   private final RestaurantService restaurantService;
-  private final RestaurantRepository restaurantRepository;
+  private final ViewCountService viewCountService;
 
   // 맛집 상세 정보 조회
   @GetMapping("/{restaurantId}")
   public ResponseEntity<RestaurantDetailResponseDto> getRestaurantDetail(
       @PathVariable String restaurantId) {
-    RestaurantDetailResponseDto restaurantDetail = restaurantService.getRedisOrDB(restaurantId);
+    RestaurantDetailResponseDto restaurantDetail =
+        restaurantService.getRestaurantDetail(restaurantId);
+    viewCountService.incrementViewCount(restaurantId);
     return ResponseEntity.ok(restaurantDetail);
   }
 

--- a/src/main/java/com/lucky/around/meal/controller/request/RestaurantDetailsRequestDto.java
+++ b/src/main/java/com/lucky/around/meal/controller/request/RestaurantDetailsRequestDto.java
@@ -1,0 +1,12 @@
+package com.lucky.around.meal.controller.request;
+
+public record RestaurantDetailsRequestDto(
+    String id,
+    String restaurantName,
+    String dosi,
+    String sigungu,
+    String jibunDetailAddress,
+    String doroDetailAddress,
+    String category,
+    String restaurantTel,
+    double ratingAverage) {}

--- a/src/main/java/com/lucky/around/meal/controller/response/RatingResponseDto.java
+++ b/src/main/java/com/lucky/around/meal/controller/response/RatingResponseDto.java
@@ -2,10 +2,18 @@ package com.lucky.around.meal.controller.response;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.*;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
 public record RatingResponseDto(
     Long ratingId,
     Long memberId,
     String restaurantId,
     Integer score,
     String content,
-    LocalDateTime createAt) {}
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+        LocalDateTime createAt) {}


### PR DESCRIPTION
## 🍚 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #87 

## 🍚 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 대규모 트래픽 대비 맛집 상세정보 조회수 N 이상만 캐싱

## 🍚 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 맛집 상세정보 조회(캐싱)
![image](https://github.com/user-attachments/assets/692a4568-1d67-4bd7-b3f4-85d693cf9f92)
- 조회수 N개 이상 캐싱 및 조회
![image](https://github.com/user-attachments/assets/bd4f236f-08a3-491f-985b-22bc3531810f)


## 🍚 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
- 맛집 상세정보 조회 시 평가 리스트도 포함되므로 캐싱도 마찬가지로 평가 리스트가 포함됨
- 점심과 저녁 시간대 기준으로 1시간 전에 새로 조회수 데이터를 수집함으로써, 오늘의 점심/저녁 실시간 인기 맛집을 선별하여 제공할 수 있음