### PR TITLE
[TEST] 맛집 상세 조회 및 조회수 캐싱 기능 테스트

### DIFF
--- a/src/test/java/com/lucky/around/meal/cache/service/ViewCountServiceTest.java
+++ b/src/test/java/com/lucky/around/meal/cache/service/ViewCountServiceTest.java
@@ -1,0 +1,146 @@
+package com.lucky.around.meal.cache.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+
+import org.junit.jupiter.api.*;
+import org.locationtech.jts.geom.Point;
+import org.mockito.*;
+import org.springframework.data.redis.core.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lucky.around.meal.controller.response.RestaurantDetailResponseDto;
+import com.lucky.around.meal.entity.Restaurant;
+import com.lucky.around.meal.entity.enums.Category;
+import com.lucky.around.meal.repository.RestaurantRepository;
+
+class ViewCountServiceTest {
+
+  private static final String VIEW_COUNT_KEY_PREFIX = "viewCount:";
+  private static final String HOURLY_VIEW_COUNT_KEY_PREFIX = "hourlyViewCount:";
+  private static final String RESTAURANT_DETAIL_KEY_PREFIX = "restaurantDetail::";
+  private static final String RESTAURANT_ID = "300000-12-000465";
+  private static final String OTHER_RESTAURANT_ID = "300000-23-0000567";
+
+  @Mock private StringRedisTemplate redisTemplate;
+  @Mock private RestaurantRepository restaurantRepository;
+  @Mock private ObjectMapper objectMapper;
+  @InjectMocks private ViewCountService viewCountService;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  @DisplayName("특정 맛집의 전체 및 시간별 조회수 증가")
+  void testIncrementViewCount() {
+    // Given
+    ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+
+    // When
+    viewCountService.incrementViewCount(RESTAURANT_ID);
+
+    // Then
+    verify(valueOps, times(1)).increment(eq(VIEW_COUNT_KEY_PREFIX + RESTAURANT_ID), eq(1L));
+    verify(valueOps, times(1)).increment(eq(HOURLY_VIEW_COUNT_KEY_PREFIX + RESTAURANT_ID), eq(1L));
+  }
+
+  @Test
+  @DisplayName("조회수 데이터가 존재하지 않을 때 : 조회수 0")
+  void testGetViewCountWhenValueDoesNotExist() {
+    // Given
+    ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    when(valueOps.get(eq(VIEW_COUNT_KEY_PREFIX + OTHER_RESTAURANT_ID))).thenReturn(null);
+
+    // When
+    Long viewCount = viewCountService.getViewCount(OTHER_RESTAURANT_ID);
+
+    // Then
+    assertEquals(0L, viewCount);
+  }
+
+  @Test
+  @DisplayName("조회수 데이터가 존재할 때 : 전체 조회수를 조회")
+  void testGetViewCountWhenValueExists() {
+    // Given
+    ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    when(valueOps.get(eq(VIEW_COUNT_KEY_PREFIX + OTHER_RESTAURANT_ID))).thenReturn("10");
+
+    // When
+    Long viewCount = viewCountService.getViewCount(OTHER_RESTAURANT_ID);
+
+    // Then
+    assertEquals(10L, viewCount);
+  }
+
+  @Test
+  @DisplayName("1시간 기준 조회수 N개 이상 캐싱 처리")
+  void testUpdateHourlyViewCountCache() throws JsonProcessingException {
+    // Given
+    Restaurant restaurant = createRestaurant();
+    ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+
+    Set<String> hourlyKeys =
+        Set.of(
+            HOURLY_VIEW_COUNT_KEY_PREFIX + RESTAURANT_ID,
+            HOURLY_VIEW_COUNT_KEY_PREFIX + OTHER_RESTAURANT_ID);
+    when(redisTemplate.keys(HOURLY_VIEW_COUNT_KEY_PREFIX + "*")).thenReturn(hourlyKeys);
+    when(valueOps.get(HOURLY_VIEW_COUNT_KEY_PREFIX + RESTAURANT_ID)).thenReturn("15");
+    when(valueOps.get(HOURLY_VIEW_COUNT_KEY_PREFIX + OTHER_RESTAURANT_ID)).thenReturn("5");
+
+    when(restaurantRepository.findById(RESTAURANT_ID))
+        .thenReturn(java.util.Optional.of(restaurant));
+    when(objectMapper.writeValueAsString(any(RestaurantDetailResponseDto.class)))
+        .thenReturn("json");
+
+    // When
+    viewCountService.updateHourlyViewCountCache();
+
+    // Then
+    verify(valueOps, never()).set(RESTAURANT_DETAIL_KEY_PREFIX + OTHER_RESTAURANT_ID, "json");
+  }
+
+  @Test
+  @DisplayName("1시간 기준 조회수 초기화")
+  void testResetViewCounts() {
+    // Given
+    Set<String> keys =
+        Set.of(HOURLY_VIEW_COUNT_KEY_PREFIX + "123", HOURLY_VIEW_COUNT_KEY_PREFIX + "456");
+    when(redisTemplate.keys(HOURLY_VIEW_COUNT_KEY_PREFIX + "*")).thenReturn(keys);
+    ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+
+    // When
+    viewCountService.resetViewCounts();
+
+    // Then
+    verify(valueOps, times(2)).set(anyString(), eq("0"));
+  }
+
+  private Restaurant createRestaurant() {
+    Point location = mock(Point.class);
+    when(location.getX()).thenReturn(12.1010);
+    when(location.getY()).thenReturn(11.6666);
+
+    return Restaurant.builder()
+        .id(RESTAURANT_ID)
+        .restaurantName("Test")
+        .dosi("서울")
+        .sigungu("중구")
+        .jibunDetailAddress("Test 주소")
+        .doroDetailAddress("Test 도로명")
+        .category(Category.FAMILY_RESTAURANT)
+        .restaurantTel("010-2222-5555")
+        .ratingAverage(5.0)
+        .location(location)
+        .build();
+  }
+}

--- a/src/test/java/com/lucky/around/meal/service/RestaurantServiceTest.java
+++ b/src/test/java/com/lucky/around/meal/service/RestaurantServiceTest.java
@@ -7,11 +7,10 @@ import java.time.LocalDateTime;
 import java.util.*;
 
 import org.junit.jupiter.api.*;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.*;
 import org.mockito.*;
 
+import com.lucky.around.meal.cache.service.ViewCountService;
 import com.lucky.around.meal.common.util.GeometryUtil;
 import com.lucky.around.meal.controller.response.*;
 import com.lucky.around.meal.entity.*;
@@ -22,7 +21,9 @@ import com.lucky.around.meal.repository.*;
 
 class RestaurantServiceTest {
 
-  private static final String RESTAURANT_ID = "3000000-101-2023-00222";
+  private static final String RESTAURANT_ID_1 = "3000000-101-2023-00221";
+  private static final String RESTAURANT_ID_2 = "3000000-101-2023-00222";
+  private static final String RESTAURANT_ID_3 = "3000000-101-2023-00223";
   private static final String RESTAURANT_NAME = "Test Restaurant";
   private static final String DOSI = "서울특별시";
   private static final String SIGUNGU = "중구";
@@ -33,16 +34,19 @@ class RestaurantServiceTest {
   private static final double LAT = 78.910;
   private static final String RATING_CONTENT = "5점 만점";
   private static final int RATING_SCORE = 5;
+  private static final double RATING_AVERAGE = 5.0;
+
+  @InjectMocks private RestaurantService restaurantService;
 
   @Mock private RestaurantRepository restaurantRepository;
 
   @Mock private RatingRepository ratingRepository;
 
-  @Mock private Member member;
-
-  @InjectMocks private RestaurantService restaurantService;
+  @Mock private ViewCountService viewCountService;
 
   @Mock private GeometryUtil geometryUtil;
+
+  @Mock private Member member;
 
   @BeforeEach
   void setUp() {
@@ -56,14 +60,15 @@ class RestaurantServiceTest {
     GeometryFactory geometryFactory = new GeometryFactory();
     Point mockLocation = geometryFactory.createPoint(new Coordinate(LON, LAT));
     when(geometryUtil.createPoint(LON, LAT)).thenReturn(mockLocation);
-    Restaurant restaurant = createRestaurant();
+    Restaurant restaurant = createRestaurant(RESTAURANT_ID_1);
     Rating rating = createRating(restaurant);
-    when(restaurantRepository.findById(RESTAURANT_ID)).thenReturn(Optional.of(restaurant));
-    when(ratingRepository.findByRestaurantIdOrderByCreateAtDesc(RESTAURANT_ID))
+    when(restaurantRepository.findById(RESTAURANT_ID_1)).thenReturn(Optional.of(restaurant));
+    when(ratingRepository.findByRestaurantIdOrderByCreateAtDesc(RESTAURANT_ID_1))
         .thenReturn(Collections.singletonList(rating));
 
     // When
-    RestaurantDetailResponseDto responseDto = restaurantService.getRestaurantDetail(RESTAURANT_ID);
+    RestaurantDetailResponseDto responseDto =
+        restaurantService.getRestaurantDetail(RESTAURANT_ID_1);
 
     // Then
     verifyRestaurantDetailResponse(responseDto, rating);
@@ -73,19 +78,51 @@ class RestaurantServiceTest {
   @DisplayName("맛집 상세 정보 조회 실패 - 해당 맛집이 존재하지 않음")
   void getRestaurantDetail_restaurantNotFound() {
     // Given
-    when(restaurantRepository.findById(RESTAURANT_ID)).thenReturn(Optional.empty());
+    when(restaurantRepository.findById(RESTAURANT_ID_1)).thenReturn(Optional.empty());
 
     // When & Then
     CustomException thrown =
         assertThrows(
-            CustomException.class, () -> restaurantService.getRestaurantDetail(RESTAURANT_ID));
+            CustomException.class, () -> restaurantService.getRestaurantDetail(RESTAURANT_ID_1));
     assertEquals(RestaurantExceptionType.RESTAURANT_NOT_FOUND, thrown.getExceptionType());
   }
 
-  private Restaurant createRestaurant() {
-    Point location = geometryUtil.createPoint(LON, LAT);
+  @Test
+  @DisplayName("조회수 기준으로 맛집 상세 목록 정렬 성공")
+  void getRestaurantsSortedByViewCount_success() {
+    // Given
+    Restaurant restaurant1 = createRestaurant(RESTAURANT_ID_1);
+    Restaurant restaurant2 = createRestaurant(RESTAURANT_ID_2);
+    Restaurant restaurant3 = createRestaurant(RESTAURANT_ID_3);
+
+    Map<String, Long> viewCounts =
+        Map.of(
+            RESTAURANT_ID_1, 10L,
+            RESTAURANT_ID_2, 30L,
+            RESTAURANT_ID_3, 20L);
+
+    List<Restaurant> restaurants = List.of(restaurant1, restaurant2, restaurant3);
+    when(restaurantRepository.findAll()).thenReturn(restaurants);
+    when(viewCountService.getAllViewCounts()).thenReturn(viewCounts);
+
+    // When
+    List<RestaurantDetailResponseDto> sortedRestaurants =
+        restaurantService.getRestaurantsSortedByViewCount("desc");
+
+    // Then
+    assertEquals(3, sortedRestaurants.size());
+    assertEquals(RESTAURANT_ID_2, sortedRestaurants.get(0).restaurantId());
+    assertEquals(RESTAURANT_ID_3, sortedRestaurants.get(1).restaurantId());
+    assertEquals(RESTAURANT_ID_1, sortedRestaurants.get(2).restaurantId());
+  }
+
+  private Restaurant createRestaurant(String id) {
+    Point location = mock(Point.class);
+    when(location.getX()).thenReturn(LON);
+    when(location.getY()).thenReturn(LAT);
+
     return Restaurant.builder()
-        .id(RESTAURANT_ID)
+        .id(id)
         .restaurantName(RESTAURANT_NAME)
         .dosi(DOSI)
         .sigungu(SIGUNGU)
@@ -93,6 +130,7 @@ class RestaurantServiceTest {
         .doroDetailAddress(DORO_ADDRESS)
         .category(Category.FAMILY_RESTAURANT)
         .restaurantTel(RESTAURANT_TEL)
+        .ratingAverage(RATING_AVERAGE)
         .location(location)
         .build();
   }
@@ -110,7 +148,7 @@ class RestaurantServiceTest {
   private void verifyRestaurantDetailResponse(
       RestaurantDetailResponseDto responseDto, Rating rating) {
     assertNotNull(responseDto);
-    assertEquals(RESTAURANT_ID, responseDto.restaurantId());
+    assertEquals(RESTAURANT_ID_1, responseDto.restaurantId());
     assertEquals(RESTAURANT_NAME, responseDto.restaurantName());
     assertEquals(DOSI, responseDto.dosi());
     assertEquals(SIGUNGU, responseDto.sigungu());


### PR DESCRIPTION
## 🍚 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #89 

## 🍚 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 특정 맛집의 전체 및 시간별 조회수 증가 테스트
- 조회수 데이터가 존재하지 않을 때, 0 반환 테스트
- 조회수 데이터가 존재할 때 전체 조회수 반환 테스트
- 1시간 기준 조회수 N개 이상 캐싱 처리
- 1시간 기준 조회수 초기화 테스트
- 조회수 기준으로 맛집 상세 목록 정렬 테스트

## 🍚 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- RestaurantServiceTest
![image](https://github.com/user-attachments/assets/6331c5dd-e1c7-44bc-bd62-3eecbe7e35b3)
- ViewCountServiceTest
![image](https://github.com/user-attachments/assets/919139f3-0d68-4f5d-a5fa-3610d3bc347d)

## 🍚 To Reviewer
<!-- 리뷰 받고 싶은 포인트를 작성합니다 -->
- 